### PR TITLE
Configure app for release v1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,8 +65,10 @@ dependencies {
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }
 
+version = '1.3'
+
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = "food-bridge-${project.version}.jar"
 }
 
 defaultTasks 'clean', 'test'

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -36,7 +36,7 @@ import seedu.address.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(0, 2, 2, true);
+    public static final Version VERSION = new Version(1, 3, 0, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 


### PR DESCRIPTION
Updated the app version and the shadowJar file name. Jar files should now be named like `food-bridge-1.3.jar`.