### PR TITLE
Fix: Add field identifiers to person list

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -27,11 +27,16 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <Label fx:id="region" styleClass="cell_small_label" text="\$region" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-      <FlowPane fx:id="orders" />
-      <FlowPane fx:id="tags" />
+      <GridPane hgap="5">
+        <Label GridPane.columnIndex="0" GridPane.rowIndex="0" styleClass="cell_small_label" text="Region: "/>
+        <Label GridPane.columnIndex="1" GridPane.rowIndex="0" fx:id="region" styleClass="cell_small_label" text="\$region" />
+        <Label GridPane.columnIndex="0" GridPane.rowIndex="1" styleClass="cell_small_label" text="Phone: "/>
+        <Label GridPane.columnIndex="1" GridPane.rowIndex="1" fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+        <Label GridPane.columnIndex="0" GridPane.rowIndex="2" styleClass="cell_small_label" text="Address: "/>
+        <Label GridPane.columnIndex="1" GridPane.rowIndex="2" fx:id="address" styleClass="cell_small_label" text="\$address" />
+        <Label GridPane.columnIndex="0" GridPane.rowIndex="3" styleClass="cell_small_label" text="Tags: "/>
+        <FlowPane GridPane.columnIndex="1" GridPane.rowIndex="3" fx:id="tags" />
+      </GridPane>
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
Closes #137. Closes #127.

Now each field has an identifier label:
<img width="1169" height="854" alt="Screenshot 2026-04-05 at 1 09 03 PM" src="https://github.com/user-attachments/assets/270228a0-5ae2-4f64-8490-b331ae8d295a" />

ALTERNATIVE: Inline labels. Would this be better? The order list uses this layout currently. Lmk because I'm not sure
<img width="1169" height="854" alt="Screenshot 2026-04-05 at 1 04 53 PM" src="https://github.com/user-attachments/assets/10d5d107-b79b-4bf6-a2ad-2f3aa332ce3e" />