### PR TITLE
Fix: Implement Alpha Testing Suggestions for the Clear Orders Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/order/ClearOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/order/ClearOrderCommand.java
@@ -17,16 +17,21 @@ public class ClearOrderCommand extends Command {
 
     public static final String COMMAND_WORD = "clearorder";
     public static final String MESSAGE_SUCCESS = "Orders have been cleared!";
+    public static final String MESSAGE_NO_ORDERS = "No order(s) to clear.";
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
+        if (model.getAddressBook().getOrderList().isEmpty()) {
+            return new CommandResult(MESSAGE_NO_ORDERS, false, false, false, true);
+        }
+
         AddressBook clearedAddressBook = new AddressBook(model.getAddressBook());
         clearedAddressBook.setOrders(Collections.emptyList());
         model.setAddressBook(clearedAddressBook);
 
-        return new CommandResult(MESSAGE_SUCCESS, false, false, false, false);
+        return new CommandResult(MESSAGE_SUCCESS, false, false, false, true);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/order/ClearOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/order/ClearOrderCommandTest.java
@@ -26,16 +26,16 @@ public class ClearOrderCommandTest {
         expectedModel.setAddressBook(clearedAddressBook);
 
         assertCommandSuccess(new ClearOrderCommand(), model,
-                new CommandResult(ClearOrderCommand.MESSAGE_SUCCESS, false, false, false, false), expectedModel);
+                new CommandResult(ClearOrderCommand.MESSAGE_SUCCESS, false, false, false, true), expectedModel);
     }
 
     @Test
-    public void execute_emptyOrderList_success() {
+    public void execute_emptyOrderList_showsNoOrdersMessage() {
         Model model = new ModelManager(new AddressBook(), new UserPrefs());
         Model expectedModel = new ModelManager(new AddressBook(), new UserPrefs());
 
         assertCommandSuccess(new ClearOrderCommand(), model,
-                new CommandResult(ClearOrderCommand.MESSAGE_SUCCESS, false, false, false, false), expectedModel);
+                new CommandResult(ClearOrderCommand.MESSAGE_NO_ORDERS, false, false, false, true), expectedModel);
     }
 
     @Test


### PR DESCRIPTION
Added a message "No order(s) to clear." that appears when there are no orders in the order list. Closes #175. Closes #204 