### PR TITLE
FIx code issues from PE-D

### DIFF
--- a/src/main/java/seedu/address/logic/commands/order/FindOrderByRegionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/order/FindOrderByRegionCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.Model;
 import seedu.address.model.order.RegionPredicate;
 
 /**
- * Finds and lists all active orders in address book whose customer's region matches the given region.
+ * Finds and lists all non-cancelled orders in address book whose customer's region matches the given region.
  */
 public class FindOrderByRegionCommand extends Command {
 
@@ -18,7 +18,7 @@ public class FindOrderByRegionCommand extends Command {
     private final RegionPredicate predicate;
 
     /**
-     * Creates a command to find active orders by customer region.
+     * Creates a command to find orders by customer region.
      */
     public FindOrderByRegionCommand(RegionPredicate predicate) {
         requireNonNull(predicate);

--- a/src/main/java/seedu/address/logic/parser/order/FindOrderByPredicateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/order/FindOrderByPredicateCommandParser.java
@@ -57,7 +57,7 @@ public class FindOrderByPredicateCommandParser implements Parser<Command> {
         }
 
         if (hasRegion) {
-            Region region = ParserUtil.parseRegion(argMultimap.getValue(PREFIX_REGION).get());
+            Region region = ParserUtil.parseRegion(argMultimap.getValue(PREFIX_REGION).get().toUpperCase());
             return new FindOrderByRegionCommand(new RegionPredicate(region));
         }
 

--- a/src/main/java/seedu/address/model/order/RegionPredicate.java
+++ b/src/main/java/seedu/address/model/order/RegionPredicate.java
@@ -18,7 +18,7 @@ public class RegionPredicate implements Predicate<OrderMap> {
     @Override
     public boolean test(OrderMap order) {
         return order.getPerson().getRegion().equals(region)
-                && order.getStatus() == OrderStatus.PENDING;
+                && order.getStatus() != OrderStatus.CANCELLED;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/order/FindOrderByPredicateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/order/FindOrderByPredicateCommandParserTest.java
@@ -49,6 +49,7 @@ public class FindOrderByPredicateCommandParserTest {
         FindOrderByRegionCommand expectedFindCommand =
                 new FindOrderByRegionCommand(new RegionPredicate(new Region("N")));
         assertParseSuccess(parser, " r/N", expectedFindCommand);
+        assertParseSuccess(parser, " r/n", expectedFindCommand);
         assertParseSuccess(parser, " \n r/N \t", expectedFindCommand);
     }
 

--- a/src/test/java/seedu/address/model/order/RegionPredicateTest.java
+++ b/src/test/java/seedu/address/model/order/RegionPredicateTest.java
@@ -3,6 +3,8 @@ package seedu.address.model.order;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.person.Person;
@@ -29,11 +31,22 @@ public class RegionPredicateTest {
     }
 
     @Test
-    public void test_completedOrder_returnsFalse() {
+    public void test_completedOrder_returnsTrue() {
         RegionPredicate predicate = new RegionPredicate(new Region("N"));
         Person person = new PersonBuilder().withRegion("N").build();
         OrderMap completedOrder = new OrderBuilder().withPerson(person).build().markAsCompleted();
-        assertFalse(predicate.test(completedOrder));
+        assertTrue(predicate.test(completedOrder));
+    }
+
+    @Test
+    public void test_cancelledOrder_returnsFalse() {
+        RegionPredicate predicate = new RegionPredicate(new Region("N"));
+        Person person = new PersonBuilder().withRegion("N").build();
+        OrderMap cancelledOrder = new OrderMap(1, person,
+                new OrderBuilder().getDefaultOrderMap(),
+                OrderStatus.CANCELLED,
+                new OrderDateTime(LocalDateTime.now()));
+        assertFalse(predicate.test(cancelledOrder));
     }
 
     @Test


### PR DESCRIPTION
## Summary of Changes

### ✅ Behavior Updates

1. **`findorder r/REGION` is now case-insensitive**
   - Lowercase inputs like `findorder r/n` are accepted and treated the same as `findorder r/N`.

2. **`findorder r/REGION` now returns both pending and completed orders**
   - Region filtering no longer limits results to only pending orders.
   - Cancelled orders remain excluded.

---

### ✅ Implementation Changes

- **`src/main/java/seedu/address/logic/parser/order/FindOrderByPredicateCommandParser.java`**
  - Region input is normalized with `toUpperCase()` before parsing in the `r/` branch.

- **`src/main/java/seedu/address/model/order/RegionPredicate.java`**
  - Predicate logic changed from:
    - `status == PENDING`
  - to:
    - `status != CANCELLED`
  - Effect: includes **PENDING + COMPLETED**, excludes **CANCELLED**.

- **`src/main/java/seedu/address/logic/commands/order/FindOrderByRegionCommand.java`**
  - Command comments/docstrings updated to match new semantics (non-cancelled region orders).

---

### ✅ Test Updates

- **`src/test/java/seedu/address/logic/parser/order/FindOrderByPredicateCommandParserTest.java`**
  - Added success case for lowercase region input:
    - `r/n` parses successfully.

- **`src/test/java/seedu/address/model/order/RegionPredicateTest.java`**
  - Updated expectation: completed orders in matching region now return `true`.
  - Added cancelled-order test to ensure cancelled orders are still excluded.
  - Existing region-match / region-mismatch tests remain valid.

---

### ✅ Result

The `findorder` command now supports more user-friendly region input and shows a fuller regional order view (pending + completed), while preserving exclusion of cancelled orders.

Closes #240. Closes #238. Closes #235. Closes #223. Closes #220.